### PR TITLE
Fix proj build command

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737085085,
-        "narHash": "sha256-5b6ytCXd7RTQAt0/4uFbZPre98SkCEKNeedaLsbdYE4=",
+        "lastModified": 1737161504,
+        "narHash": "sha256-plqfUiAXUy75dg/jBMLfXnrypImMftF4Qxso8MOS0Po=",
         "owner": "lockshaw",
         "repo": "proj",
-        "rev": "d6a664dfc4a378d6b9cfaf9937cd9514f164c558",
+        "rev": "e2400466cf6ffa3e2c231449add3c47d0298d045",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**Description of changes:**

#1578 updated to a new version of proj that contained a bug in the `proj build` command, this commit updates nix-locked proj to version https://github.com/lockshaw/proj/commit/e2400466cf6ffa3e2c231449add3c47d0298d045 which contains a fix.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1580)
<!-- Reviewable:end -->
