### PR TITLE
Update dtgen to add docstring support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737161504,
-        "narHash": "sha256-plqfUiAXUy75dg/jBMLfXnrypImMftF4Qxso8MOS0Po=",
+        "lastModified": 1737340566,
+        "narHash": "sha256-fIRXCPLjOZ7QweKH6GanI4BjMotMdp4M9r6/V3l/eXo=",
         "owner": "lockshaw",
         "repo": "proj",
-        "rev": "e2400466cf6ffa3e2c231449add3c47d0298d045",
+        "rev": "2394e855baeea5757c75eadde748902988db5509",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**Description of changes:**

dtgen now supports specifying Doxygen docstrings in `.struct.toml` ([top-level docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/person.struct.toml#L3-L7), [field docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/person.struct.toml#L33)), `.enum.toml` ([top-level docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/color.enum.toml#L3-L7), [value docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/color.enum.toml#L23)), and `.variant.toml` ([top-level docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/int_or_bool.variant.toml#L3), [value docstring example](https://github.com/lockshaw/proj/blob/2394e855baeea5757c75eadde748902988db5509/tests/dtgen/person/include/int_or_bool.variant.toml#L16)) files.

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1581)
<!-- Reviewable:end -->
