### PR TITLE
Automatically push deps to cachix in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: cachix/cachix-action@v14
         with:
           name: ff
-          skipPush: ${{ github.head_ref == 'master' || github.head_ref == 'auto-build-deps' }}
+          skipPush: ${{ github.head_ref == 'master' }}
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: setup nix develop shell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: cachix/cachix-action@v14
         with:
           name: ff
-          skipPush: true
-          # authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          skipPush: ${{ github.head_ref == 'master' || github.head_ref == 'auto-build-deps' }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: setup nix develop shell
         uses: nicknovitski/nix-develop@v1.1.0

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     ];
     extra-trusted-public-keys = [
       "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
-      "ff.cachix.org-1:/kyZ0w35ToSJBjpiNfPLrL3zTjuPkUiqf2WH0GIShXM="
+      "ff.cachix.org-1:IRdsNEnht4YKGUasP6SX5DfpaOTBckhpJDEODz7wMFM="
     ];
   };
 


### PR DESCRIPTION
**Description of changes:**

Automatically push build dependencies to `ff.cachix.org` in CI (for `master` only).

**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1603)
<!-- Reviewable:end -->
