### PR TITLE
Missed GASNet in the deploy script for Sapling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Depedencies
         run: |
           apt-get update -qq
-          apt-get install -y build-essential cmake curl gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }} git libibverbs-dev libmpich-dev mpich python3 python3-venv zlib1g-dev
+          apt-get install -y build-essential cmake curl gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }} git libibverbs-dev libmpich-dev mpich pkg-config python3 python3-venv zlib1g-dev
 
       - name: Run Deploy Script
         run: ./deploy/sapling.sh

--- a/deploy/sapling.sh
+++ b/deploy/sapling.sh
@@ -102,7 +102,7 @@ build_cmake_library cpptrace https://github.com/jeremy-rifkin/cpptrace/archive/r
 
 build_cmake_library libassert https://github.com/jeremy-rifkin/libassert/archive/refs/tags/v2.2.1.tar.gz -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DLIBASSERT_USE_EXTERNAL_CPPTRACE=ON
 
-build_cmake_library Realm https://github.com/StanfordLegion/realm.git -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DREALM_ENABLE_CUDA=ON -DREALM_ENABLE_PREALM=ON -DREALM_ENABLE_CPPTRACE=ON -DREALM_ENABLE_HDF5=OFF -DREALM_MAX_DIM=5
+build_cmake_library Realm https://github.com/StanfordLegion/realm.git -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON -DREALM_ENABLE_GASNETEX=ON -DREALM_ENABLE_CUDA=ON -DREALM_ENABLE_PREALM=ON -DREALM_ENABLE_CPPTRACE=ON -DREALM_ENABLE_HDF5=OFF -DREALM_MAX_DIM=5
 
 build_cmake_library benchmark https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DBENCHMARK_DOWNLOAD_DEPENDENCIES=ON
 


### PR DESCRIPTION
I thought it auto-detected, but apparently not. Need to explicitly enable GASNet in Realm build to get a distributed version.

Edit: Currently not ready to merge this yet. It is an issue with any distributed deployments, but I'll need to change the approach to make sure it's compatible with CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1664)
<!-- Reviewable:end -->
