### PR TITLE
Remove contains template parameter to enable overloads

### DIFF
--- a/lib/utils/include/utils/containers/contains.h
+++ b/lib/utils/include/utils/containers/contains.h
@@ -7,7 +7,7 @@ namespace FlexFlow {
 
 template <typename Container>
 bool contains(Container const &c, typename Container::value_type const &e) {
-  return find<Container>(c, e) != c.cend();
+  return find(c, e) != c.cend();
 }
 
 } // namespace FlexFlow


### PR DESCRIPTION
This one-line change results in an 7.4x performance in copy insertion.

`find` has two overloads. Note that the template parameters differ between them (one takes a container type and one takes a value type):

https://github.com/flexflow/flexflow-train/blob/7664ef80ead6b18c401004d5c22182dfce51755b/lib/utils/include/utils/containers/find.h#L9-L18

The implementation of `contains` explicitly uses a template parameter with the type of the container, not value. This forces the first overload and falls back to `std::find` (linear search).

I considered modifying `find` itself to use template specialization instead of overloads, but the code is a lot more convoluted to achieve the same effect. (And besides, the overload pattern is pervasive throughout the codebase and this would multiply if we did it everywhere.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1672)
<!-- Reviewable:end -->
