### PR TITLE
Accumulate merge_disjoint_maps functions in single pass

### DIFF
--- a/lib/utils/include/utils/containers/merge_disjoint_maps.h
+++ b/lib/utils/include/utils/containers/merge_disjoint_maps.h
@@ -1,8 +1,7 @@
 #ifndef _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_DISJOINT_MAPS_H
 #define _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_DISJOINT_MAPS_H
 
-#include "utils/containers/binary_merge_disjoint_maps.h"
-#include "utils/containers/foldl.h"
+#include "utils/containers/merge_in_disjoint_map.h"
 
 namespace FlexFlow {
 
@@ -10,12 +9,11 @@ template <typename C,
           typename K = typename C::value_type::key_type,
           typename V = typename C::value_type::mapped_type>
 std::map<K, V> merge_disjoint_maps(C const &c) {
-  std::map<K, V> empty = {};
-  return foldl(c,
-               /*init=*/empty,
-               [](std::map<K, V> const &lhs, std::map<K, V> const &rhs) {
-                 return binary_merge_disjoint_maps(lhs, rhs);
-               });
+  std::map<K, V> result;
+  for (auto const &m : c) {
+    merge_in_disjoint_map(m, result);
+  }
+  return result;
 }
 
 } // namespace FlexFlow

--- a/lib/utils/include/utils/containers/merge_disjoint_unordered_maps.h
+++ b/lib/utils/include/utils/containers/merge_disjoint_unordered_maps.h
@@ -1,8 +1,7 @@
 #ifndef _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_DISJOINT_UNORDERED_MAPS_H
 #define _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_DISJOINT_UNORDERED_MAPS_H
 
-#include "utils/containers/binary_merge_disjoint_unordered_maps.h"
-#include "utils/containers/foldl.h"
+#include "utils/containers/merge_in_disjoint_unordered_map.h"
 
 namespace FlexFlow {
 
@@ -10,13 +9,11 @@ template <typename C,
           typename K = typename C::value_type::key_type,
           typename V = typename C::value_type::mapped_type>
 std::unordered_map<K, V> merge_disjoint_unordered_maps(C const &c) {
-  std::unordered_map<K, V> empty = {};
-  return foldl(c,
-               /*init=*/empty,
-               [](std::unordered_map<K, V> const &lhs,
-                  std::unordered_map<K, V> const &rhs) {
-                 return binary_merge_disjoint_unordered_maps(lhs, rhs);
-               });
+  std::unordered_map<K, V> result;
+  for (auto const &m : c) {
+    merge_in_disjoint_unordered_map(m, result);
+  }
+  return result;
 }
 
 } // namespace FlexFlow

--- a/lib/utils/include/utils/containers/merge_in_disjoint_map.h
+++ b/lib/utils/include/utils/containers/merge_in_disjoint_map.h
@@ -1,0 +1,19 @@
+#ifndef _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_IN_DISJOINT_MAP_H
+#define _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_IN_DISJOINT_MAP_H
+
+#include <libassert/assert.hpp>
+#include <map>
+
+namespace FlexFlow {
+
+template <typename K, typename V>
+void merge_in_disjoint_map(std::map<K, V> const &m, std::map<K, V> &result) {
+  for (auto const &kv : m) {
+    bool inserted = result.insert(kv).second;
+    ASSERT(inserted);
+  }
+}
+
+} // namespace FlexFlow
+
+#endif

--- a/lib/utils/include/utils/containers/merge_in_disjoint_unordered_map.h
+++ b/lib/utils/include/utils/containers/merge_in_disjoint_unordered_map.h
@@ -7,7 +7,8 @@
 namespace FlexFlow {
 
 template <typename K, typename V>
-void merge_in_disjoint_unordered_map(std::unordered_map<K, V> const &m, std::unordered_map<K, V> &result) {
+void merge_in_disjoint_unordered_map(std::unordered_map<K, V> const &m,
+                                     std::unordered_map<K, V> &result) {
   for (auto const &kv : m) {
     bool inserted = result.insert(kv).second;
     ASSERT(inserted);

--- a/lib/utils/include/utils/containers/merge_in_disjoint_unordered_map.h
+++ b/lib/utils/include/utils/containers/merge_in_disjoint_unordered_map.h
@@ -1,0 +1,19 @@
+#ifndef _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_IN_DISJOINT_UNORDERED_MAP_H
+#define _FLEXFLOW_LIB_UTILS_INCLUDE_UTILS_CONTAINERS_MERGE_IN_DISJOINT_UNORDERED_MAP_H
+
+#include <libassert/assert.hpp>
+#include <unordered_map>
+
+namespace FlexFlow {
+
+template <typename K, typename V>
+void merge_in_disjoint_unordered_map(std::unordered_map<K, V> const &m, std::unordered_map<K, V> &result) {
+  for (auto const &kv : m) {
+    bool inserted = result.insert(kv).second;
+    ASSERT(inserted);
+  }
+}
+
+} // namespace FlexFlow
+
+#endif

--- a/lib/utils/src/utils/containers/merge_in_disjoint_map.cc
+++ b/lib/utils/src/utils/containers/merge_in_disjoint_map.cc
@@ -1,0 +1,11 @@
+#include "utils/containers/merge_in_disjoint_map.h"
+#include "utils/archetypes/ordered_value_type.h"
+
+namespace FlexFlow {
+
+using K = ordered_value_type<0>;
+using V = ordered_value_type<1>;
+
+template void merge_in_disjoint_map(std::map<K, V> const &, std::map<K, V> &);
+
+} // namespace FlexFlow

--- a/lib/utils/src/utils/containers/merge_in_disjoint_unordered_map.cc
+++ b/lib/utils/src/utils/containers/merge_in_disjoint_unordered_map.cc
@@ -7,6 +7,6 @@ using K = value_type<0>;
 using V = value_type<1>;
 
 template void merge_in_disjoint_unordered_map(std::unordered_map<K, V> const &,
-                                     std::unordered_map<K, V> &);
+                                              std::unordered_map<K, V> &);
 
 } // namespace FlexFlow

--- a/lib/utils/src/utils/containers/merge_in_disjoint_unordered_map.cc
+++ b/lib/utils/src/utils/containers/merge_in_disjoint_unordered_map.cc
@@ -1,0 +1,12 @@
+#include "utils/containers/merge_in_disjoint_unordered_map.h"
+#include "utils/archetypes/value_type.h"
+
+namespace FlexFlow {
+
+using K = value_type<0>;
+using V = value_type<1>;
+
+template void merge_in_disjoint_unordered_map(std::unordered_map<K, V> const &,
+                                     std::unordered_map<K, V> &);
+
+} // namespace FlexFlow


### PR DESCRIPTION
Using `foldl` with a growing data structure results in `O(N^2)` total time complexity. Fixing this to use linear time merge results in an additional 6.6x performance improvement in copy insertion (after applying #1672).

I should note that there's a similar hazard in `merge_maps_with` which I have not fixed here, that is likely to impact the compiler. However that case doesn't impact the runtime so I am not attempting to fix it here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1673)
<!-- Reviewable:end -->
