### PR TITLE
Update all instances of ProfilingSettings to pass at least 1 iter

### DIFF
--- a/bin/run-model/src/run-model/main.cc
+++ b/bin/run-model/src/run-model/main.cc
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
             /*optimizer=*/optimizer_attrs,
             /*loss=*/std::nullopt,
             /*input_tensors=*/input_tensors,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0, 1},
             /*device_handle=*/device_handle,
             /*device_type=*/DeviceType::GPU);
 

--- a/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
+++ b/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
@@ -161,7 +161,7 @@ TEST_SUITE(FF_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0, 1},
             /*device_handle=*/ff_handle,
             /*global_device_id=*/global_device_id);
 
@@ -172,7 +172,7 @@ TEST_SUITE(FF_TEST_SUITE) {
     for (int i = 0; i < num_epochs; i++) {
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0, 1},
           /*ff_handle=*/ff_handle,
           /*global_device_id=*/global_device_id);
       loss_values.push_back(copy_tensor_accessor_r(
@@ -335,7 +335,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0, 1},
             /*device_handle=*/ff_handle,
             /*device_idx=*/device_idx);
 
@@ -348,7 +348,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
     for (int i = 0; i < num_epochs; i++) {
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0, 1},
           /*ff_handle=*/ff_handle,
           /*device_idx=*/device_idx);
       loss_values.push_back(copy_tensor_accessor_r(
@@ -465,7 +465,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
 
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0, 1},
           /*ff_handle=*/ff_handle,
           /*device_idx=*/device_idx);
       assert_unwrap(computation_graph_instance.get_loss_tensor_accessor());

--- a/lib/local-execution/test/src/local-execution/local_task_argument_accessor.cc
+++ b/lib/local-execution/test/src/local-execution/local_task_argument_accessor.cc
@@ -62,7 +62,7 @@ TEST_SUITE(FF_TEST_SUITE) {
     LocalTaskArgumentAccessor acc = LocalTaskArgumentAccessor{
         /*allocator=*/allocator,
         /*tensor_slots_backing=*/tensor_slots_backing,
-        /*profiling_settings=*/ProfilingSettings{0, 0},
+        /*profiling_settings=*/ProfilingSettings{0, 1},
         /*ff_handle=*/cpu_make_device_handle_t(),
         /*op_attrs=*/PCGOperatorAttrs{InputAttrs{input_tensor_shape}},
         /*loss_attrs=*/std::nullopt,

--- a/lib/realm-execution/test/src/realm-execution/test_e2e.cc
+++ b/lib/realm-execution/test/src/realm-execution/test_e2e.cc
@@ -449,7 +449,7 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*loss_mapping=*/cfg.loss_mapping,
           },
           /*input_tensors=*/input_tensors,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0, 1},
           /*device_handle=*/device_handle,
           /*device_type=*/DeviceType::CPU);
 
@@ -460,7 +460,7 @@ TEST_SUITE(FF_TEST_SUITE) {
       for (int i = 0; i < num_epochs; i++) {
         perform_all_passes_for_pcg_instance(
             /*instance=*/pcg_instance,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0, 1},
             /*device_handle=*/device_handle);
         loss_values.push_back(copy_tensor_accessor_r(
             dynamic_tensor_accessor_from_instance(
@@ -522,7 +522,7 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0, 1},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::CPU);
 
@@ -531,7 +531,7 @@ TEST_SUITE(FF_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0, 1},
                 /*device_handle=*/device_handle);
           }
         });
@@ -579,7 +579,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
                   /*loss_mapping=*/cfg.loss_mapping,
               },
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0, 1},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -590,7 +590,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0, 1},
                 /*device_handle=*/device_handle);
 
             loss_values.push_back(copy_tensor_accessor_r(
@@ -657,7 +657,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0, 1},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -666,7 +666,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0, 1},
                 /*device_handle=*/device_handle);
           }
         });


### PR DESCRIPTION
I previously submitted #1657 but then decided to withdraw it. This PR at least updates all instances of `ProfilingSettings` to pass 1 iter, otherwise all of our e2e style tests don't run anything.

This could cause some of our tests to become unreliable: some places still use uninitialized data, and if we happen to get `NaN`s, can cause the `<=` checks on loss to fail. However, that is strictly speaking a separate issue.

The alternative would be to go back to #1657 and establish data types that enforce a positive number of iterations, but then we lose the ability to shut off execution via `ProfilingSettings`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1674)
<!-- Reviewable:end -->
