### PR TITLE
Use the largest device memory available under Realm

### DIFF
--- a/lib/realm-execution/src/realm-execution/dynamic_tensor_accessor_from_instance.cc
+++ b/lib/realm-execution/src/realm-execution/dynamic_tensor_accessor_from_instance.cc
@@ -15,6 +15,7 @@ static DeviceType infer_device_type_from_memory_and_processor(
       device_type = DeviceType::CPU;
       break;
     case Realm::Memory::GPU_FB_MEM:
+    case Realm::Memory::GPU_DYNAMIC_MEM:
       // Only accessible on GPU
       device_type = DeviceType::GPU;
       break;

--- a/lib/realm-execution/src/realm-execution/realm_context.cc
+++ b/lib/realm-execution/src/realm-execution/realm_context.cc
@@ -158,12 +158,21 @@ Realm::Memory RealmContext::get_nearest_memory(Realm::Processor proc) {
     return Realm::Memory::NO_MEMORY;
   }
 
-  // FIMXE: this isn't going to do what you expect until
-  // https://github.com/StanfordLegion/realm/pull/392 merges
   Realm::Machine::MemoryQuery mq(Realm::Machine::get_machine());
   mq.best_affinity_to(proc);
   ASSERT(mq.count() > 0);
-  return mq.first();
+
+  // Among the best memories, pick the one with the largest capacity
+  Realm::Memory result = Realm::Memory::NO_MEMORY;
+  for (Realm::Machine::MemoryQuery::iterator it = mq.begin(); it != mq.end();
+       ++it) {
+    if (!result.exists() || it->capacity() > result.capacity()) {
+      result = *it;
+    }
+  }
+
+  ASSERT(result.exists());
+  return result;
 }
 
 Realm::Processor RealmContext::get_current_processor() const {


### PR DESCRIPTION
Given a set of multiple "best" memories (according to Realm), pick the one with the largest capacity.

This is a relatively minor point but avoids some potential footguns for new users who don't know how to configure Realm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1675)
<!-- Reviewable:end -->
