### PR TITLE
ProfilingSettings takes a nonnegative_int and a positive_int

### DIFF
--- a/bin/run-model/src/run-model/main.cc
+++ b/bin/run-model/src/run-model/main.cc
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
             /*optimizer=*/optimizer_attrs,
             /*loss=*/std::nullopt,
             /*input_tensors=*/input_tensors,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/device_handle,
             /*device_type=*/DeviceType::GPU);
 
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < num_epochs; i++) {
           perform_all_passes_for_pcg_instance(
               /*instance=*/pcg_instance,
-              /*profiling_settings=*/ProfilingSettings{0, 1},
+              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle);
         }
       });

--- a/lib/kernels/include/kernels/profiling.h
+++ b/lib/kernels/include/kernels/profiling.h
@@ -17,8 +17,8 @@ std::optional<milliseconds_t> profiling_wrapper(F const &f,
                                                 Ts &&...ts) {
   if (enable_profiling) {
     ProfilingSettings settings = ProfilingSettings{
-        /*warmup_iters=*/0,
-        /*measure_iters=*/1,
+        /*warmup_iters=*/0_n,
+        /*measure_iters=*/1_p,
     };
     return profiling_wrapper<F, Ts...>(f, settings, std::forward<Ts>(ts)...);
   } else {
@@ -28,15 +28,10 @@ std::optional<milliseconds_t> profiling_wrapper(F const &f,
 }
 
 template <typename F, typename... Ts>
-std::optional<milliseconds_t>
-    profiling_wrapper(F const &f,
-                      ProfilingSettings const &settings,
-                      DeviceType device_type,
-                      Ts &&...ts) {
-  if (settings.measure_iters <= 0) {
-    return std::nullopt;
-  }
-
+milliseconds_t profiling_wrapper(F const &f,
+                                 ProfilingSettings const &settings,
+                                 DeviceType device_type,
+                                 Ts &&...ts) {
   if (device_type == DeviceType::GPU) {
     return gpu_profiling_wrapper(f, settings, std::forward<Ts>(ts)...);
   } else {
@@ -49,8 +44,6 @@ template <typename F, typename... Ts>
 milliseconds_t cpu_profiling_wrapper(F const &f,
                                      ProfilingSettings const &settings,
                                      Ts &&...ts) {
-  ASSERT(settings.measure_iters > 0);
-
   device_stream_t stream = get_cpu_device_stream();
 
   using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
@@ -58,7 +51,9 @@ milliseconds_t cpu_profiling_wrapper(F const &f,
   std::optional<TimePoint> start = std::nullopt;
   std::optional<TimePoint> end = std::nullopt;
 
-  for (int i = 0; i < settings.warmup_iters + settings.measure_iters; i++) {
+  for (nonnegative_int i = 0_n;
+       i < settings.warmup_iters + settings.measure_iters;
+       ++i) {
     if (i == settings.warmup_iters) {
       start = std::chrono::steady_clock::now();
     }
@@ -67,7 +62,8 @@ milliseconds_t cpu_profiling_wrapper(F const &f,
   end = std::chrono::steady_clock::now();
 
   std::chrono::duration<double, std::milli> avg_duration =
-      (end.value() - start.value()) / settings.measure_iters;
+      (end.value() - start.value()) /
+      settings.measure_iters.int_from_positive_int();
 
   return milliseconds_t{
       static_cast<float>(avg_duration.count()),
@@ -78,15 +74,15 @@ template <typename F, typename... Ts>
 milliseconds_t gpu_profiling_wrapper(F const &f,
                                      ProfilingSettings const &settings,
                                      Ts &&...ts) {
-  ASSERT(settings.measure_iters > 0);
-
   device_stream_t stream = get_gpu_device_stream();
 
   ffEvent_t t_start, t_end;
   checkCUDA(ffEventCreate(&t_start));
   checkCUDA(ffEventCreate(&t_end));
 
-  for (int i = 0; i < settings.warmup_iters + settings.measure_iters; i++) {
+  for (nonnegative_int i = 0_n;
+       i < settings.warmup_iters + settings.measure_iters;
+       ++i) {
     if (i == settings.warmup_iters) {
       checkCUDA(ffEventRecord(t_start, stream.require_gpu()));
     }
@@ -100,7 +96,7 @@ milliseconds_t gpu_profiling_wrapper(F const &f,
   checkCUDA(ffEventDestroy(t_start));
   checkCUDA(ffEventDestroy(t_end));
   return milliseconds_t{
-      elapsed / settings.measure_iters,
+      elapsed / settings.measure_iters.int_from_positive_int(),
   };
 }
 

--- a/lib/kernels/include/kernels/profiling_settings.dtg.toml
+++ b/lib/kernels/include/kernels/profiling_settings.dtg.toml
@@ -10,10 +10,16 @@ features = [
   "fmt",
 ]
 
+includes = [
+  "utils/nonnegative_int/nonnegative_int.h",
+  "utils/positive_int/positive_int.h",
+]
+
 [[fields]]
 name = "warmup_iters"
-type = "int"
+type = "::FlexFlow::nonnegative_int"
+
 
 [[fields]]
 name = "measure_iters"
-type = "int"
+type = "::FlexFlow::positive_int"

--- a/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
+++ b/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
@@ -161,7 +161,7 @@ TEST_SUITE(FF_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/ff_handle,
             /*global_device_id=*/global_device_id);
 
@@ -172,7 +172,7 @@ TEST_SUITE(FF_TEST_SUITE) {
     for (int i = 0; i < num_epochs; i++) {
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
           /*ff_handle=*/ff_handle,
           /*global_device_id=*/global_device_id);
       loss_values.push_back(copy_tensor_accessor_r(
@@ -335,7 +335,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/ff_handle,
             /*device_idx=*/device_idx);
 
@@ -348,7 +348,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
     for (int i = 0; i < num_epochs; i++) {
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
           /*ff_handle=*/ff_handle,
           /*device_idx=*/device_idx);
       loss_values.push_back(copy_tensor_accessor_r(
@@ -459,13 +459,13 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
               },
               /*input_tensors=*/input_tensors,
               /*allocator=*/allocator,
-              /*profiling_settings=*/ProfilingSettings{0, 1},
+              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/ff_handle,
               /*device_idx=*/device_idx);
 
       perform_all_passes_for_computation_graph_instance(
           /*instance=*/computation_graph_instance,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
           /*ff_handle=*/ff_handle,
           /*device_idx=*/device_idx);
       assert_unwrap(computation_graph_instance.get_loss_tensor_accessor());

--- a/lib/local-execution/test/src/local-execution/cost_estimator/local_cost_estimator.cc
+++ b/lib/local-execution/test/src/local-execution/cost_estimator/local_cost_estimator.cc
@@ -44,8 +44,8 @@ TEST_SUITE(FF_TEST_SUITE) {
         /*interconnect_specification=*/interconnect_specification,
         /*allocator=*/allocator,
         /*profiling_settings=*/
-        ProfilingSettings{/*warmup_iters=*/0,
-                          /*measure_iters=*/1},
+        ProfilingSettings{/*warmup_iters=*/0_n,
+                          /*measure_iters=*/1_p},
         /*device_handle=*/ff_handle,
         /*device_idx=*/device_idx);
 
@@ -121,8 +121,8 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
         /*interconnect_specification=*/interconnect_specification,
         /*allocator=*/allocator,
         /*profiling_settings=*/
-        ProfilingSettings{/*warmup_iters=*/0,
-                          /*measure_iters=*/1},
+        ProfilingSettings{/*warmup_iters=*/0_n,
+                          /*measure_iters=*/1_p},
         /*device_handle=*/ff_handle,
         /*device_idx=*/device_idx);
 

--- a/lib/local-execution/test/src/local-execution/local_task_argument_accessor.cc
+++ b/lib/local-execution/test/src/local-execution/local_task_argument_accessor.cc
@@ -62,7 +62,7 @@ TEST_SUITE(FF_TEST_SUITE) {
     LocalTaskArgumentAccessor acc = LocalTaskArgumentAccessor{
         /*allocator=*/allocator,
         /*tensor_slots_backing=*/tensor_slots_backing,
-        /*profiling_settings=*/ProfilingSettings{0, 0},
+        /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
         /*ff_handle=*/cpu_make_device_handle_t(),
         /*op_attrs=*/PCGOperatorAttrs{InputAttrs{input_tensor_shape}},
         /*loss_attrs=*/std::nullopt,

--- a/lib/realm-execution/test/src/realm-execution/test_e2e.cc
+++ b/lib/realm-execution/test/src/realm-execution/test_e2e.cc
@@ -449,7 +449,7 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*loss_mapping=*/cfg.loss_mapping,
           },
           /*input_tensors=*/input_tensors,
-          /*profiling_settings=*/ProfilingSettings{0, 0},
+          /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
           /*device_handle=*/device_handle,
           /*device_type=*/DeviceType::CPU);
 
@@ -460,7 +460,7 @@ TEST_SUITE(FF_TEST_SUITE) {
       for (int i = 0; i < num_epochs; i++) {
         perform_all_passes_for_pcg_instance(
             /*instance=*/pcg_instance,
-            /*profiling_settings=*/ProfilingSettings{0, 0},
+            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/device_handle);
         loss_values.push_back(copy_tensor_accessor_r(
             dynamic_tensor_accessor_from_instance(
@@ -522,7 +522,7 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::CPU);
 
@@ -531,7 +531,7 @@ TEST_SUITE(FF_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
           }
         });
@@ -579,7 +579,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
                   /*loss_mapping=*/cfg.loss_mapping,
               },
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -590,7 +590,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
 
             loss_values.push_back(copy_tensor_accessor_r(
@@ -657,7 +657,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0, 0},
+              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -666,7 +666,7 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0, 0},
+                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
           }
         });


### PR DESCRIPTION
Cloning from https://github.com/flexflow/flexflow-train/pull/1657 because GitHub is weird and doesn't seem to be updating to my changes.

This currently fails with:

```
Panic at ../lib/kernels/src/kernels/element_binary_kernels_cpu.cc:11: void FlexFlow::Kernels::ElementBinary::cpu_forward_kernel(const float*, const float*, float*, FlexFlow::OperatorType, bool): Not implemented
```

Which is not going to be resolved until https://github.com/flexflow/flexflow-train/pull/1667 merges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1679)
<!-- Reviewable:end -->
