### PR TITLE
Add ability to bypass profiling entirely by making ProfilingSettings optional

### DIFF
--- a/bin/run-model/src/run-model/main.cc
+++ b/bin/run-model/src/run-model/main.cc
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
             /*optimizer=*/optimizer_attrs,
             /*loss=*/std::nullopt,
             /*input_tensors=*/input_tensors,
-            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
+            /*profiling_settings=*/std::nullopt,
             /*device_handle=*/device_handle,
             /*device_type=*/DeviceType::GPU);
 
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < num_epochs; i++) {
           perform_all_passes_for_pcg_instance(
               /*instance=*/pcg_instance,
-              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
+              /*profiling_settings=*/std::nullopt,
               /*device_handle=*/device_handle);
         }
       });

--- a/bin/run-model/src/run-model/main.cc
+++ b/bin/run-model/src/run-model/main.cc
@@ -101,7 +101,6 @@ int main(int argc, char **argv) {
             /*optimizer=*/optimizer_attrs,
             /*loss=*/std::nullopt,
             /*input_tensors=*/input_tensors,
-            /*profiling_settings=*/std::nullopt,
             /*device_handle=*/device_handle,
             /*device_type=*/DeviceType::GPU);
 
@@ -110,7 +109,6 @@ int main(int argc, char **argv) {
         for (int i = 0; i < num_epochs; i++) {
           perform_all_passes_for_pcg_instance(
               /*instance=*/pcg_instance,
-              /*profiling_settings=*/std::nullopt,
               /*device_handle=*/device_handle);
         }
       });

--- a/lib/local-execution/include/local-execution/computation_graph_instance.h
+++ b/lib/local-execution/include/local-execution/computation_graph_instance.h
@@ -46,31 +46,30 @@ ComputationGraphInstance create_computation_graph_instance(
     std::optional<LossConfig> const &loss,
     std::map<DynamicValueAttrs, DynamicTensorAccessor> const &input_tensors,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
     device_handle_t const &device_handle,
     global_device_id_t global_device_id);
 
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_all_passes_for_computation_graph_instance(
         ComputationGraphInstance &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t global_device_id);
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_forward_pass_for_computation_graph_instance(
         ComputationGraphInstance const &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t global_device_id);
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_backward_pass_for_computation_graph_instance(
         ComputationGraphInstance const &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t global_device_id);
 void perform_update_pass_for_computation_graph_instance(
     ComputationGraphInstance &instance,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     global_device_id_t global_device_id);
 

--- a/lib/local-execution/include/local-execution/local_task_argument_accessor.h
+++ b/lib/local-execution/include/local-execution/local_task_argument_accessor.h
@@ -15,7 +15,7 @@ struct LocalTaskArgumentAccessor : public ITaskArgumentAccessor {
       Allocator const &allocator,
       std::map<TaskTensorParameter, DynamicTensorAccessor> const
           &tensor_slots_backing,
-      ProfilingSettings const &profiling_settings,
+      std::optional<ProfilingSettings> const &profiling_settings,
       device_handle_t const &ff_handle,
       std::optional<PCGOperatorAttrs> const &op_attrs,
       std::optional<LossAttrs> const &loss_attrs,
@@ -31,7 +31,7 @@ struct LocalTaskArgumentAccessor : public ITaskArgumentAccessor {
   GenericTensorAccessor get_tensor(TaskTensorParameter slot,
                                    Permissions priv) const override;
 
-  ProfilingSettings get_profiling_settings() const override;
+  std::optional<ProfilingSettings> get_profiling_settings() const override;
   device_handle_t get_ff_handle() const override;
   DeviceType get_kernel_device_type() const override;
   PCGOperatorAttrs get_op_attrs() const override;
@@ -47,7 +47,7 @@ private:
   Allocator allocator;
   std::map<TaskTensorParameter, DynamicTensorAccessor> tensor_slots_backing;
 
-  ProfilingSettings profiling_settings;
+  std::optional<ProfilingSettings> profiling_settings;
   device_handle_t ff_handle;
   DeviceType kernel_device_type;
   std::optional<PCGOperatorAttrs> op_attrs;

--- a/lib/local-execution/include/local-execution/per_device_op_state_initialization.h
+++ b/lib/local-execution/include/local-execution/per_device_op_state_initialization.h
@@ -12,13 +12,11 @@ namespace FlexFlow {
 
 bool no_nodes_are_initialized(DynamicOpenDataflowGraph const &g);
 
-DynamicNodeInvocation
-    initialize_node(DynamicNodeInvocation const &i,
-                    Allocator &allocator,
-                    ProfilingSettings const &profiling_settings,
-                    device_handle_t const &device_handle,
-                    OptimizerAttrs const &optimizer_attrs,
-                    global_device_id_t device_idx);
+DynamicNodeInvocation initialize_node(DynamicNodeInvocation const &i,
+                                      Allocator &allocator,
+                                      device_handle_t const &device_handle,
+                                      OptimizerAttrs const &optimizer_attrs,
+                                      global_device_id_t device_idx);
 
 /**
  * @brief Initialize all operators and save the per-device op state
@@ -26,7 +24,6 @@ DynamicNodeInvocation
 DynamicOpenDataflowGraph perform_per_device_op_state_initialization(
     DynamicOpenDataflowGraph const &,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
     device_handle_t const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     global_device_id_t device_idx);

--- a/lib/local-execution/include/local-execution/task_execution.h
+++ b/lib/local-execution/include/local-execution/task_execution.h
@@ -12,7 +12,7 @@ namespace FlexFlow {
 TaskArgumentAccessor make_task_argument_accessor_for_invocation(
     DynamicNodeInvocation const &invocation,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     std::optional<PerDeviceOpState> const &per_device_op_state,
     std::optional<OptimizerAttrs> const &optimizer_attrs,
@@ -21,7 +21,7 @@ TaskArgumentAccessor make_task_argument_accessor_for_invocation(
 std::optional<milliseconds_t> execute_dynamic_node_invocation(
     DynamicNodeInvocation const &invocation,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     std::optional<PerDeviceOpState> const &per_device_op_state,
     std::optional<OptimizerAttrs> const &optimizer_attrs,

--- a/lib/local-execution/src/local-execution/computation_graph_instance.cc
+++ b/lib/local-execution/src/local-execution/computation_graph_instance.cc
@@ -64,7 +64,6 @@ ComputationGraphInstance create_computation_graph_instance(
     std::optional<LossConfig> const &loss,
     std::map<DynamicValueAttrs, DynamicTensorAccessor> const &input_tensors,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
     device_handle_t const &device_handle,
     global_device_id_t device_idx) {
   DynamicOpenDataflowGraph dg = make_dynamic_open_dataflow_graph_from_cg(cg);
@@ -89,12 +88,8 @@ ComputationGraphInstance create_computation_graph_instance(
         return get_loss_tensor_accessor(dg, lgv);
       });
 
-  dg = perform_per_device_op_state_initialization(dg,
-                                                  allocator,
-                                                  profiling_settings,
-                                                  device_handle,
-                                                  optimizer_attrs,
-                                                  device_idx);
+  dg = perform_per_device_op_state_initialization(
+      dg, allocator, device_handle, optimizer_attrs, device_idx);
 
   // Compute the topological ordering of the graph
   auto [kwarg_graph, node_map] =
@@ -112,7 +107,7 @@ static std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
         std::vector<DynamicNodeInvocation> const &invocations,
         Allocator &allocator,
         OptimizerAttrs const &optimizer_attrs,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t device_idx) {
   return map_from_pairs(
@@ -137,7 +132,7 @@ static std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_all_passes_for_computation_graph_instance(
         ComputationGraphInstance &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t device_idx) {
   std::vector<DynamicNodeInvocation> execution_order =
@@ -157,7 +152,7 @@ std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_forward_pass_for_computation_graph_instance(
         ComputationGraphInstance const &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t device_idx) {
   std::vector<DynamicNodeInvocation> execution_order =
@@ -180,7 +175,7 @@ std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
 std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
     perform_backward_pass_for_computation_graph_instance(
         ComputationGraphInstance const &instance,
-        ProfilingSettings const &profiling_settings,
+        std::optional<ProfilingSettings> const &profiling_settings,
         device_handle_t const &ff_handle,
         global_device_id_t device_idx) {
   std::vector<DynamicNodeInvocation> execution_order =
@@ -202,7 +197,7 @@ std::map<dynamic_layer_guid_t, std::optional<milliseconds_t>>
 
 void perform_update_pass_for_computation_graph_instance(
     ComputationGraphInstance &instance,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     global_device_id_t device_idx) {
   std::vector<DynamicNodeInvocation> execution_order =

--- a/lib/local-execution/src/local-execution/cost_estimator/local_cost_estimator.cc
+++ b/lib/local-execution/src/local-execution/cost_estimator/local_cost_estimator.cc
@@ -122,7 +122,6 @@ OpCostMetrics LocalCostEstimator::estimate_cost(
       /*loss=*/std::nullopt,
       /*input_tensors=*/{},
       /*allocator=*/allocator,
-      /*profiling_settings=*/this->profiling_settings,
       /*device_handle=*/this->device_handle,
       /*device_idx=*/this->device_idx);
 

--- a/lib/local-execution/src/local-execution/local_task_argument_accessor.cc
+++ b/lib/local-execution/src/local-execution/local_task_argument_accessor.cc
@@ -10,7 +10,7 @@ LocalTaskArgumentAccessor::LocalTaskArgumentAccessor(
     Allocator const &allocator,
     std::map<TaskTensorParameter, DynamicTensorAccessor> const
         &tensor_slots_backing,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     std::optional<PCGOperatorAttrs> const &op_attrs,
     std::optional<LossAttrs> const &loss_attrs,
@@ -73,7 +73,8 @@ GenericTensorAccessor
   }
 }
 
-ProfilingSettings LocalTaskArgumentAccessor::get_profiling_settings() const {
+std::optional<ProfilingSettings>
+    LocalTaskArgumentAccessor::get_profiling_settings() const {
   return this->profiling_settings;
 }
 

--- a/lib/local-execution/src/local-execution/per_device_op_state_initialization.cc
+++ b/lib/local-execution/src/local-execution/per_device_op_state_initialization.cc
@@ -18,13 +18,11 @@ bool no_nodes_are_initialized(DynamicOpenDataflowGraph const &g) {
       }));
 }
 
-DynamicNodeInvocation
-    initialize_node(DynamicNodeInvocation const &i,
-                    Allocator &allocator,
-                    ProfilingSettings const &profiling_settings,
-                    device_handle_t const &device_handle,
-                    OptimizerAttrs const &optimizer_attrs,
-                    global_device_id_t device_idx) {
+DynamicNodeInvocation initialize_node(DynamicNodeInvocation const &i,
+                                      Allocator &allocator,
+                                      device_handle_t const &device_handle,
+                                      OptimizerAttrs const &optimizer_attrs,
+                                      global_device_id_t device_idx) {
   if (!i.node_attrs.op_attrs.has_value() ||
       !i.node_attrs.op_attrs.value().is_pcg_op()) {
     return i;
@@ -40,7 +38,7 @@ DynamicNodeInvocation
       make_task_argument_accessor_for_invocation(
           /*invocation=*/i,
           /*allocator=*/allocator,
-          /*profiling_settings=*/profiling_settings,
+          /*profiling_settings=*/std::nullopt,
           /*ff_handle=*/device_handle,
           /*per_device_op_state=*/std::nullopt,
           /*optimizer_attrs=*/optimizer_attrs,
@@ -58,7 +56,6 @@ DynamicNodeInvocation
 DynamicOpenDataflowGraph perform_per_device_op_state_initialization(
     DynamicOpenDataflowGraph const &dg,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
     device_handle_t const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     global_device_id_t device_idx) {
@@ -66,12 +63,8 @@ DynamicOpenDataflowGraph perform_per_device_op_state_initialization(
   ASSERT(no_nodes_are_initialized(dg));
   DynamicOpenDataflowGraph result = transform_dynamic_invocation_set(
       dg, [&](DynamicNodeInvocation const &invocation) {
-        return initialize_node(invocation,
-                               allocator,
-                               profiling_settings,
-                               device_handle,
-                               optimizer_attrs,
-                               device_idx);
+        return initialize_node(
+            invocation, allocator, device_handle, optimizer_attrs, device_idx);
       });
 
   return result;

--- a/lib/local-execution/src/local-execution/task_execution.cc
+++ b/lib/local-execution/src/local-execution/task_execution.cc
@@ -45,7 +45,7 @@ TaskTensorParameter make_task_tensor_parameter_from_dynamic_slot(
 TaskArgumentAccessor make_task_argument_accessor_for_invocation(
     DynamicNodeInvocation const &invocation,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     std::optional<PerDeviceOpState> const &per_device_op_state,
     std::optional<OptimizerAttrs> const &optimizer_attrs,
@@ -84,7 +84,7 @@ TaskArgumentAccessor make_task_argument_accessor_for_invocation(
 std::optional<milliseconds_t> execute_dynamic_node_invocation(
     DynamicNodeInvocation const &invocation,
     Allocator &allocator,
-    ProfilingSettings const &profiling_settings,
+    std::optional<ProfilingSettings> const &profiling_settings,
     device_handle_t const &ff_handle,
     std::optional<PerDeviceOpState> const &per_device_op_state,
     std::optional<OptimizerAttrs> const &optimizer_attrs,

--- a/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
+++ b/lib/local-execution/test/src/local-execution/computation_graph_instance.cc
@@ -161,7 +161,6 @@ TEST_SUITE(FF_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/ff_handle,
             /*global_device_id=*/global_device_id);
 
@@ -335,7 +334,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
             },
             /*input_tensors=*/input_tensors,
             /*allocator=*/allocator,
-            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/ff_handle,
             /*device_idx=*/device_idx);
 
@@ -459,7 +457,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
               },
               /*input_tensors=*/input_tensors,
               /*allocator=*/allocator,
-              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/ff_handle,
               /*device_idx=*/device_idx);
 

--- a/lib/realm-execution/include/realm-execution/distributed_per_device_op_state_initialization.h
+++ b/lib/realm-execution/include/realm-execution/distributed_per_device_op_state_initialization.h
@@ -1,7 +1,6 @@
 #ifndef _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_DISTRIBUTED_PER_DEVICE_OP_STATE_INITIALIZATION_H
 #define _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_DISTRIBUTED_PER_DEVICE_OP_STATE_INITIALIZATION_H
 
-#include "kernels/profiling_settings.dtg.h"
 #include "pcg/optimizer_attrs.dtg.h"
 #include "realm-execution/distributed_ff_handle.h"
 #include "realm-execution/per_device_op_state_backing.dtg.h"
@@ -22,7 +21,6 @@ PerDeviceOpStateBacking perform_distributed_per_device_op_state_initialization(
     RealmContext &ctx,
     DynamicOpenDataflowGraph const &dg,
     TensorInstanceBacking const &tensor_instance_backing,
-    ProfilingSettings const &profiling_settings,
     DistributedFfHandle const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     Realm::Event precondition);

--- a/lib/realm-execution/include/realm-execution/pcg_instance.h
+++ b/lib/realm-execution/include/realm-execution/pcg_instance.h
@@ -3,7 +3,6 @@
 
 #include "kernels/allocation.h"
 #include "kernels/device_handle_t.dtg.h"
-#include "kernels/profiling_settings.dtg.h"
 #include "pcg/mapped_parallel_computation_graph/mapped_parallel_computation_graph.dtg.h"
 #include "pcg/optimizer_attrs.dtg.h"
 #include "realm-execution/distributed_ff_handle.h"
@@ -84,7 +83,6 @@ PCGInstance create_pcg_instance(
     OptimizerAttrs const &optimizer_attrs,
     std::optional<ParallelLossConfig> const &loss,
     std::map<DynamicValueAttrs, DynamicTensorAccessor> const &input_tensors,
-    ProfilingSettings const &profiling_settings,
     DistributedFfHandle const &ff_handle,
     DeviceType device_type);
 
@@ -100,28 +98,20 @@ PCGInstance create_pcg_instance(
  * \relates PCGInstance
  */
 std::map<dynamic_layer_guid_t, Realm::Event>
-    perform_all_passes_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &ff_handle);
+    perform_all_passes_for_pcg_instance(PCGInstance &pcg_instance,
+                                        DistributedFfHandle const &ff_handle);
 
 std::map<dynamic_layer_guid_t, Realm::Event>
-    perform_forward_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &ff_handle);
+    perform_forward_pass_for_pcg_instance(PCGInstance &pcg_instance,
+                                          DistributedFfHandle const &ff_handle);
 
 std::map<dynamic_layer_guid_t, Realm::Event>
     perform_backward_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &ff_handle);
+        PCGInstance &pcg_instance, DistributedFfHandle const &ff_handle);
 
 std::map<dynamic_layer_guid_t, Realm::Event>
-    perform_update_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &ff_handle);
+    perform_update_pass_for_pcg_instance(PCGInstance &pcg_instance,
+                                         DistributedFfHandle const &ff_handle);
 
 } // namespace FlexFlow
 

--- a/lib/realm-execution/include/realm-execution/tasks/impl/op_task.h
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/op_task.h
@@ -1,7 +1,6 @@
 #ifndef _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_TASKS_IMPL_OP_TASK_H
 #define _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_TASKS_IMPL_OP_TASK_H
 
-#include "kernels/profiling_settings.dtg.h"
 #include "op-attrs/ops/loss_functions/loss_attrs.dtg.h"
 #include "pcg/optimizer_attrs.dtg.h"
 #include "realm-execution/device_specific_managed_per_device_ff_handle.h"
@@ -57,7 +56,6 @@ Realm::Event spawn_op_task(
     DynamicNodeInvocation const &invocation,
     TensorInstanceBacking const &tensor_backing,
     std::optional<DeviceSpecificPtr<PerDeviceOpState>> const &device_state,
-    ProfilingSettings const &profiling_settings,
     DeviceSpecificPtr<ManagedPerDeviceFFHandle> const &device_handle,
     std::optional<OptimizerAttrs> const &optimizer_attrs,
     Realm::Event precondition);

--- a/lib/realm-execution/include/realm-execution/tasks/impl/op_task_args.dtg.toml
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/op_task_args.dtg.toml
@@ -4,7 +4,6 @@ type = "struct"
 features = []
 
 includes = [
-  "kernels/profiling_settings.dtg.h",
   "pcg/optimizer_attrs.dtg.h",
   "realm-execution/device_specific_managed_per_device_ff_handle.h",
   "realm-execution/device_specific_ptr.h",
@@ -24,10 +23,6 @@ type = "::FlexFlow::TensorInstanceBacking"
 [[fields]]
 name = "device_state"
 type = "std::optional<::FlexFlow::DeviceSpecificPtr<::FlexFlow::PerDeviceOpState>>"
-
-[[fields]]
-name = "profiling_settings"
-type = "::FlexFlow::ProfilingSettings"
 
 [[fields]]
 name = "device_handle"

--- a/lib/realm-execution/include/realm-execution/tasks/impl/per_device_op_state_init_task.h
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/per_device_op_state_init_task.h
@@ -1,7 +1,6 @@
 #ifndef _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_TASKS_IMPL_PER_DEVICE_OP_STATE_INIT_TASK_H
 #define _FLEXFLOW_LIB_REALM_EXECUTION_INCLUDE_REALM_EXECUTION_TASKS_IMPL_PER_DEVICE_OP_STATE_INIT_TASK_H
 
-#include "kernels/profiling_settings.dtg.h"
 #include "pcg/optimizer_attrs.dtg.h"
 #include "realm-execution/device_specific_managed_per_device_ff_handle.h"
 #include "realm-execution/device_specific_ptr.h"
@@ -36,7 +35,6 @@ std::optional<Realm::Event> spawn_per_device_op_state_init_task(
     Realm::Processor target_proc,
     DynamicNodeInvocation const &invocation,
     TensorInstanceBacking const &tensor_backing,
-    ProfilingSettings const &profiling_settings,
     DeviceSpecificPtr<ManagedPerDeviceFFHandle> const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     DeviceSpecificPtr<PerDeviceOpState> *result_ptr,

--- a/lib/realm-execution/include/realm-execution/tasks/impl/per_device_op_state_init_task_args.dtg.toml
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/per_device_op_state_init_task_args.dtg.toml
@@ -30,10 +30,6 @@ name = "tensor_backing"
 type = "TensorInstanceBacking"
 
 [[fields]]
-name = "profiling_settings"
-type = "::FlexFlow::ProfilingSettings"
-
-[[fields]]
 name = "device_handle"
 type = "::FlexFlow::DeviceSpecificPtr<::FlexFlow::ManagedPerDeviceFFHandle>"
 

--- a/lib/realm-execution/include/realm-execution/tasks/impl/serializable_op_task_args.dtg.toml
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/serializable_op_task_args.dtg.toml
@@ -9,7 +9,6 @@ features = [
 ]
 
 includes = [
-  "kernels/profiling_settings.dtg.h",
   "pcg/optimizer_attrs.dtg.h",
   "realm-execution/tasks/serializer/serializable_device_specific_ptr.dtg.h",
   "realm-execution/tasks/serializer/serializable_tensor_instance_backing.dtg.h",
@@ -32,10 +31,6 @@ type = "::FlexFlow::SerializableTensorInstanceBacking"
 [[fields]]
 name = "device_state"
 type = "std::optional<::FlexFlow::SerializableDeviceSpecificPtr>"
-
-[[fields]]
-name = "profiling_settings"
-type = "::FlexFlow::ProfilingSettings"
 
 [[fields]]
 name = "device_handle"

--- a/lib/realm-execution/include/realm-execution/tasks/impl/serializable_per_device_op_state_init_task_args.dtg.toml
+++ b/lib/realm-execution/include/realm-execution/tasks/impl/serializable_per_device_op_state_init_task_args.dtg.toml
@@ -9,7 +9,6 @@ features = [
 ]
 
 includes = [
-  "kernels/profiling_settings.dtg.h",
   "pcg/optimizer_attrs.dtg.h",
   "realm-execution/tasks/serializer/serializable_device_specific_ptr.dtg.h",
   "realm-execution/tasks/serializer/serializable_realm_processor.dtg.h",
@@ -25,10 +24,6 @@ type = "::FlexFlow::SerializableDynamicNodeInvocation"
 [[fields]]
 name = "tensor_backing"
 type = "::FlexFlow::SerializableTensorInstanceBacking"
-
-[[fields]]
-name = "profiling_settings"
-type = "::FlexFlow::ProfilingSettings"
 
 [[fields]]
 name = "device_handle"

--- a/lib/realm-execution/src/realm-execution/distributed_per_device_op_state_initialization.cc
+++ b/lib/realm-execution/src/realm-execution/distributed_per_device_op_state_initialization.cc
@@ -20,7 +20,6 @@ PerDeviceOpStateBacking perform_distributed_per_device_op_state_initialization(
     RealmContext &ctx,
     DynamicOpenDataflowGraph const &dg,
     TensorInstanceBacking const &tensor_instance_backing,
-    ProfilingSettings const &profiling_settings,
     DistributedFfHandle const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     Realm::Event precondition) {
@@ -55,7 +54,6 @@ PerDeviceOpStateBacking perform_distributed_per_device_op_state_initialization(
                                             target_proc,
                                             invocation,
                                             tensor_backing,
-                                            profiling_settings,
                                             device_handle.at(target_proc),
                                             optimizer_attrs,
                                             device_state_ptr,

--- a/lib/realm-execution/src/realm-execution/pcg_instance.cc
+++ b/lib/realm-execution/src/realm-execution/pcg_instance.cc
@@ -86,7 +86,6 @@ PCGInstance create_pcg_instance(
     OptimizerAttrs const &optimizer_attrs,
     std::optional<ParallelLossConfig> const &loss,
     std::map<DynamicValueAttrs, DynamicTensorAccessor> const &input_tensors,
-    ProfilingSettings const &profiling_settings,
     DistributedFfHandle const &device_handle,
     DeviceType device_type) {
 
@@ -151,7 +150,6 @@ PCGInstance create_pcg_instance(
           ctx,
           dg,
           tensor_instance_backing,
-          profiling_settings,
           device_handle,
           optimizer_attrs,
           ctx.get_outstanding_events());
@@ -268,7 +266,6 @@ static Realm::Event spawn_dynamic_node_invocation(
     TensorInstanceBacking const &tensor_instance_backing,
     PerDeviceOpStateBacking const &device_state_backing,
     OptimizerAttrs const &optimizer_attrs,
-    ProfilingSettings const &profiling_settings,
     DistributedFfHandle const &device_handle) {
   Realm::Event precondition = Realm::Event::merge_events(
       Realm::Event::merge_events(input_dependencies),
@@ -286,7 +283,6 @@ static Realm::Event spawn_dynamic_node_invocation(
                          invocation,
                          tensor_backing,
                          try_at(device_state_backing.backing, invocation),
-                         profiling_settings,
                          device_handle.at(target_proc),
                          optimizer_attrs,
                          precondition);
@@ -351,7 +347,6 @@ static std::map<dynamic_layer_guid_t, Realm::Event>
         TensorInstanceBacking const &tensor_instance_backing,
         PerDeviceOpStateBacking const &device_state_backing,
         OptimizerAttrs const &optimizer_attrs,
-        ProfilingSettings const &profiling_settings,
         DistributedFfHandle const &device_handle) {
   // For simplicity we'll track a dependency on all outstanding operations up to
   // this point. This will create an effective barrier between phases.
@@ -377,7 +372,6 @@ static std::map<dynamic_layer_guid_t, Realm::Event>
                                           tensor_instance_backing,
                                           device_state_backing,
                                           optimizer_attrs,
-                                          profiling_settings,
                                           device_handle);
 
         for (DynamicValueAttrs const &value : values(invocation.inputs)) {
@@ -392,9 +386,7 @@ static std::map<dynamic_layer_guid_t, Realm::Event>
 
 std::map<dynamic_layer_guid_t, Realm::Event>
     perform_all_passes_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &device_handle) {
+        PCGInstance &pcg_instance, DistributedFfHandle const &device_handle) {
   std::vector<DynamicNodeInvocation> execution_order =
       pcg_instance.get_execution_order();
   std::map<dynamic_layer_guid_t, Realm::Event> result =
@@ -405,7 +397,6 @@ std::map<dynamic_layer_guid_t, Realm::Event>
           pcg_instance.get_tensor_instance_backing(),
           /*device_state_backing=*/pcg_instance.get_device_state_backing(),
           /*optimizer_attrs=*/pcg_instance.get_optimizer_attrs(),
-          /*profiling_settings=*/profiling_settings,
           /*device_handle=*/device_handle);
   pcg_instance.update_optimizer_attrs_for_next_iter();
   return result;
@@ -413,9 +404,7 @@ std::map<dynamic_layer_guid_t, Realm::Event>
 
 std::map<dynamic_layer_guid_t, Realm::Event>
     perform_forward_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &device_handle) {
+        PCGInstance &pcg_instance, DistributedFfHandle const &device_handle) {
   std::vector<DynamicNodeInvocation> execution_order =
       filter(pcg_instance.get_execution_order(),
              [](DynamicNodeInvocation const &invocation) {
@@ -430,15 +419,12 @@ std::map<dynamic_layer_guid_t, Realm::Event>
       /*tensor_instance_backing=*/pcg_instance.get_tensor_instance_backing(),
       /*device_state_backing=*/pcg_instance.get_device_state_backing(),
       /*optimizer_attrs=*/pcg_instance.get_optimizer_attrs(),
-      /*profiling_settings=*/profiling_settings,
       /*device_handle=*/device_handle);
 }
 
 std::map<dynamic_layer_guid_t, Realm::Event>
     perform_backward_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &device_handle) {
+        PCGInstance &pcg_instance, DistributedFfHandle const &device_handle) {
   std::vector<DynamicNodeInvocation> execution_order =
       filter(pcg_instance.get_execution_order(),
              [](DynamicNodeInvocation const &invocation) {
@@ -453,15 +439,12 @@ std::map<dynamic_layer_guid_t, Realm::Event>
       /*tensor_instance_backing=*/pcg_instance.get_tensor_instance_backing(),
       /*device_state_backing=*/pcg_instance.get_device_state_backing(),
       /*optimizer_attrs=*/pcg_instance.get_optimizer_attrs(),
-      /*profiling_settings=*/profiling_settings,
       /*device_handle=*/device_handle);
 }
 
 std::map<dynamic_layer_guid_t, Realm::Event>
     perform_update_pass_for_pcg_instance(
-        PCGInstance &pcg_instance,
-        ProfilingSettings const &profiling_settings,
-        DistributedFfHandle const &device_handle) {
+        PCGInstance &pcg_instance, DistributedFfHandle const &device_handle) {
   std::vector<DynamicNodeInvocation> execution_order =
       filter(pcg_instance.get_execution_order(),
              [](DynamicNodeInvocation const &invocation) {
@@ -478,7 +461,6 @@ std::map<dynamic_layer_guid_t, Realm::Event>
           pcg_instance.get_tensor_instance_backing(),
           /*device_state_backing=*/pcg_instance.get_device_state_backing(),
           /*optimizer_attrs=*/pcg_instance.get_optimizer_attrs(),
-          /*profiling_settings=*/profiling_settings,
           /*device_handle=*/device_handle);
   pcg_instance.update_optimizer_attrs_for_next_iter();
   return result;

--- a/lib/realm-execution/src/realm-execution/tasks/impl/op_task.cc
+++ b/lib/realm-execution/src/realm-execution/tasks/impl/op_task.cc
@@ -48,7 +48,7 @@ void op_task_body(void const *args,
   execute_dynamic_node_invocation(
       /*invocation=*/invocation,
       /*allocator=*/ctx.get_current_device_allocator(),
-      /*profiling_settings=*/task_args.profiling_settings,
+      /*profiling_settings=*/std::nullopt,
       /*ff_handle=*/device_handle,
       /*per_device_op_state=*/
       transform(and_then(task_args.device_state,
@@ -66,7 +66,6 @@ Realm::Event spawn_op_task(
     DynamicNodeInvocation const &invocation,
     TensorInstanceBacking const &tensor_backing,
     std::optional<DeviceSpecificPtr<PerDeviceOpState>> const &device_state,
-    ProfilingSettings const &profiling_settings,
     DeviceSpecificPtr<ManagedPerDeviceFFHandle> const &device_handle,
     std::optional<OptimizerAttrs> const &optimizer_attrs,
     Realm::Event precondition) {
@@ -75,7 +74,6 @@ Realm::Event spawn_op_task(
       invocation,
       tensor_backing,
       device_state,
-      profiling_settings,
       device_handle,
       optimizer_attrs,
   };

--- a/lib/realm-execution/src/realm-execution/tasks/impl/per_device_op_state_init_task.cc
+++ b/lib/realm-execution/src/realm-execution/tasks/impl/per_device_op_state_init_task.cc
@@ -52,7 +52,6 @@ void per_device_op_state_init_task_body(void const *args,
   DynamicNodeInvocation result_invocation =
       initialize_node(invocation,
                       ctx.get_current_device_allocator(),
-                      task_args.profiling_settings,
                       device_handle,
                       task_args.optimizer_attrs,
                       ctx.get_current_global_device_id());
@@ -77,7 +76,6 @@ std::optional<Realm::Event> spawn_per_device_op_state_init_task(
     Realm::Processor target_proc,
     DynamicNodeInvocation const &invocation,
     TensorInstanceBacking const &tensor_backing,
-    ProfilingSettings const &profiling_settings,
     DeviceSpecificPtr<ManagedPerDeviceFFHandle> const &device_handle,
     OptimizerAttrs const &optimizer_attrs,
     DeviceSpecificPtr<PerDeviceOpState> *result_ptr,
@@ -85,7 +83,6 @@ std::optional<Realm::Event> spawn_per_device_op_state_init_task(
   PerDeviceOpStateInitTaskArgs task_args{
       invocation,
       tensor_backing,
-      profiling_settings,
       device_handle,
       optimizer_attrs,
       ctx.get_current_processor(),

--- a/lib/realm-execution/src/realm-execution/tasks/impl/serializable_op_task_args.cc
+++ b/lib/realm-execution/src/realm-execution/tasks/impl/serializable_op_task_args.cc
@@ -14,7 +14,6 @@ SerializableOpTaskArgs op_task_args_to_serializable(OpTaskArgs const &args) {
       /*device_state=*/
       transform(args.device_state,
                 device_specific_ptr_to_serializable<PerDeviceOpState>),
-      /*profiling_settings=*/args.profiling_settings,
       /*device_handle=*/device_specific_ptr_to_serializable(args.device_handle),
       /*optimizer_attrs=*/args.optimizer_attrs,
   };
@@ -28,7 +27,6 @@ OpTaskArgs op_task_args_from_serializable(SerializableOpTaskArgs const &args) {
       /*device_state=*/
       transform(args.device_state,
                 device_specific_ptr_from_serializable<PerDeviceOpState>),
-      /*profiling_settings=*/args.profiling_settings,
       /*device_handle=*/
       device_specific_ptr_from_serializable<ManagedPerDeviceFFHandle>(
           args.device_handle),

--- a/lib/realm-execution/src/realm-execution/tasks/impl/serializable_per_device_op_state_init_task_args.cc
+++ b/lib/realm-execution/src/realm-execution/tasks/impl/serializable_per_device_op_state_init_task_args.cc
@@ -13,7 +13,6 @@ SerializablePerDeviceOpStateInitTaskArgs
       /*invocation=*/dynamic_node_invocation_to_serializable(args.invocation),
       /*tensor_backing*/
       tensor_instance_backing_to_serializable(args.tensor_backing),
-      /*profiling_settings=*/args.profiling_settings,
       /*device_handle=*/device_specific_ptr_to_serializable(args.device_handle),
       /*optimizer_attrs=*/args.optimizer_attrs,
       /*origin_proc=*/realm_processor_to_serializable(args.origin_proc),
@@ -28,7 +27,6 @@ PerDeviceOpStateInitTaskArgs
       /*invocation=*/dynamic_node_invocation_from_serializable(args.invocation),
       /*tensor_backing*/
       tensor_instance_backing_from_serializable(args.tensor_backing),
-      /*profiling_settings=*/args.profiling_settings,
       /*device_handle=*/
       device_specific_ptr_from_serializable<ManagedPerDeviceFFHandle>(
           args.device_handle),

--- a/lib/realm-execution/test/src/realm-execution/test_e2e.cc
+++ b/lib/realm-execution/test/src/realm-execution/test_e2e.cc
@@ -449,7 +449,6 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*loss_mapping=*/cfg.loss_mapping,
           },
           /*input_tensors=*/input_tensors,
-          /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
           /*device_handle=*/device_handle,
           /*device_type=*/DeviceType::CPU);
 
@@ -460,7 +459,6 @@ TEST_SUITE(FF_TEST_SUITE) {
       for (int i = 0; i < num_epochs; i++) {
         perform_all_passes_for_pcg_instance(
             /*instance=*/pcg_instance,
-            /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
             /*device_handle=*/device_handle);
         loss_values.push_back(copy_tensor_accessor_r(
             dynamic_tensor_accessor_from_instance(
@@ -522,7 +520,6 @@ TEST_SUITE(FF_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::CPU);
 
@@ -531,7 +528,6 @@ TEST_SUITE(FF_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
           }
         });
@@ -579,7 +575,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
                   /*loss_mapping=*/cfg.loss_mapping,
               },
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -590,7 +585,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
 
             loss_values.push_back(copy_tensor_accessor_r(
@@ -657,7 +651,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
               /*optimizer=*/optimizer_attrs,
               /*loss=*/std::nullopt,
               /*input_tensors=*/input_tensors,
-              /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
               /*device_handle=*/device_handle,
               /*device_type=*/DeviceType::GPU);
 
@@ -666,7 +659,6 @@ TEST_SUITE(FF_CUDA_TEST_SUITE) {
           for (int i = 0; i < num_epochs; i++) {
             perform_all_passes_for_pcg_instance(
                 /*instance=*/pcg_instance,
-                /*profiling_settings=*/ProfilingSettings{0_n, 1_p},
                 /*device_handle=*/device_handle);
           }
         });

--- a/lib/task-spec/include/task-spec/profiling.h
+++ b/lib/task-spec/include/task-spec/profiling.h
@@ -2,24 +2,28 @@
 #define _FLEXFLOW_LIB_TASK_SPEC_INCLUDE_TASK_SPEC_PROFILING_H
 
 #include "kernels/profiling.h"
+#include "utils/optional.h"
 #include <spdlog/spdlog.h>
 
 namespace FlexFlow {
 
-enum class EnableProfiling { YES, NO };
-
 template <typename F, typename... Ts, typename Str>
-std::optional<milliseconds_t> profile(F const &f,
-                                      ProfilingSettings profiling,
-                                      DeviceType device_type,
-                                      Str s,
-                                      Ts &&...ts) {
-  std::optional<milliseconds_t> elapsed = profiling_wrapper<F, Ts...>(
-      f, profiling, device_type, std::forward<Ts>(ts)...);
-  if (elapsed.has_value()) {
-    spdlog::debug(s, elapsed.value());
+std::optional<milliseconds_t>
+    profile(F const &f,
+            std::optional<ProfilingSettings> const &profiling,
+            DeviceType device_type,
+            Str s,
+            Ts &&...ts) {
+  if (!profiling.has_value()) {
+    f(get_stream_for_device_type(device_type), std::forward<Ts>(ts)...);
+    return std::nullopt;
+  } else {
+    ProfilingSettings settings = assert_unwrap(profiling);
+    milliseconds_t elapsed = profiling_wrapper<F, Ts...>(
+        f, profiling.value(), device_type, std::forward<Ts>(ts)...);
+    spdlog::debug(s, elapsed);
+    return elapsed;
   }
-  return elapsed;
 }
 
 } // namespace FlexFlow

--- a/lib/task-spec/include/task-spec/task_argument_accessor/itask_argument_accessor.h
+++ b/lib/task-spec/include/task-spec/task_argument_accessor/itask_argument_accessor.h
@@ -28,7 +28,7 @@ struct ITaskArgumentAccessor {
   virtual GenericTensorAccessor get_tensor(TaskTensorParameter,
                                            Permissions priv) const = 0;
 
-  virtual ProfilingSettings get_profiling_settings() const = 0;
+  virtual std::optional<ProfilingSettings> get_profiling_settings() const = 0;
   virtual device_handle_t get_ff_handle() const = 0;
   virtual DeviceType get_kernel_device_type() const = 0;
   virtual PCGOperatorAttrs get_op_attrs() const = 0;

--- a/lib/task-spec/include/task-spec/task_argument_accessor/task_argument_accessor.h
+++ b/lib/task-spec/include/task-spec/task_argument_accessor/task_argument_accessor.h
@@ -16,7 +16,7 @@
 namespace FlexFlow {
 
 struct TaskArgumentAccessor {
-  ProfilingSettings get_profiling_settings() const;
+  std::optional<ProfilingSettings> get_profiling_settings() const;
   device_handle_t get_ff_handle() const;
   DeviceType get_kernel_device_type() const;
   PCGOperatorAttrs get_op_attrs() const;

--- a/lib/task-spec/src/task-spec/loss_functions.cc
+++ b/lib/task-spec/src/task-spec/loss_functions.cc
@@ -23,7 +23,7 @@ namespace FlexFlow {
 
 static void backward_task_impl(TaskArgumentAccessor const &acc) {
   LossAttrs attrs = acc.get_loss_attrs();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto logit_grad = acc.get_tensor_grad<Permissions::RW>(TensorSlotName::LOGIT);

--- a/lib/task-spec/src/task-spec/ops/impl/attention.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/attention.cc
@@ -89,7 +89,7 @@ static std::optional<milliseconds_t>
   auto weight = acc.get_tensor<Permissions::RO>(TensorSlotName::WEIGHT);
   auto output = acc.get_tensor<Permissions::WO>(TensorSlotName::OUTPUT);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<MHAPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_mha();
@@ -121,7 +121,7 @@ static std::optional<milliseconds_t>
   auto key_grad = acc.get_tensor_grad<Permissions::RW>(TensorSlotName::KEY);
   auto value_grad = acc.get_tensor_grad<Permissions::RW>(TensorSlotName::VALUE);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<MHAPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_mha();

--- a/lib/task-spec/src/task-spec/ops/impl/batch_matmul.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/batch_matmul.cc
@@ -7,7 +7,7 @@ namespace FlexFlow {
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   auto lhs_input = acc.get_tensor<Permissions::RO>(TensorSlotName::LHS_INPUT);
   auto rhs_input = acc.get_tensor<Permissions::RO>(TensorSlotName::RHS_INPUT);
@@ -24,7 +24,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto lhs_input = acc.get_tensor<Permissions::RO>(TensorSlotName::LHS_INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/batch_norm.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/batch_norm.cc
@@ -25,7 +25,7 @@ static DeviceSpecificPerDeviceOpState
     init_task_impl(TaskArgumentAccessor const &acc) {
   Allocator allocator = acc.get_allocator();
   device_handle_t handle = acc.get_ff_handle();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto output = acc.get_tensor<Permissions::WO>(TensorSlotName::OUTPUT);
@@ -58,7 +58,7 @@ static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
   auto per_device_state =
       acc.get_per_device_op_state().require_batch_norm().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
@@ -81,7 +81,7 @@ static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
   BatchNormPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_batch_norm().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/cast.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/cast.cc
@@ -24,7 +24,7 @@ namespace FlexFlow {
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   CastAttrs attrs = acc.get_op_attrs().require_cast();
 
@@ -41,7 +41,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   CastAttrs attrs = acc.get_op_attrs().require_cast();
 

--- a/lib/task-spec/src/task-spec/ops/impl/concat.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/concat.cc
@@ -33,7 +33,7 @@ static std::vector<TensorSlotName> get_input_slots(ConcatAttrs const &attrs) {
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ConcatAttrs attrs = acc.get_op_attrs().require_concat();
 
@@ -60,7 +60,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ConcatAttrs attrs = acc.get_op_attrs().require_concat();
 

--- a/lib/task-spec/src/task-spec/ops/impl/conv_2d.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/conv_2d.cc
@@ -41,7 +41,7 @@ static DeviceSpecificPerDeviceOpState
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   Conv2DPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_conv2d().value();
@@ -66,7 +66,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   Conv2DPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_conv2d().value();

--- a/lib/task-spec/src/task-spec/ops/impl/dropout.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/dropout.cc
@@ -33,7 +33,7 @@ static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
   DropoutPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_dropout().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
@@ -53,7 +53,7 @@ static std::optional<milliseconds_t>
 
   DropoutPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_dropout().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input_grad = acc.get_tensor_grad<Permissions::RW>(TensorSlotName::INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/element_binary.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/element_binary.cc
@@ -28,7 +28,7 @@ static DeviceSpecificPerDeviceOpState
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<ElementBinaryPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_element_binary();
@@ -56,7 +56,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<ElementBinaryPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_element_binary();

--- a/lib/task-spec/src/task-spec/ops/impl/element_unary.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/element_unary.cc
@@ -34,7 +34,7 @@ static std::optional<milliseconds_t>
 
   device_handle_t handle = acc.get_ff_handle();
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<ElementUnaryPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_element_unary();
@@ -64,7 +64,7 @@ static std::optional<milliseconds_t>
   ElementUnaryAttrs attrs = acc.get_op_attrs().require_element_unary();
   device_handle_t handle = acc.get_ff_handle();
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   std::optional<ElementUnaryPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_element_unary();

--- a/lib/task-spec/src/task-spec/ops/impl/embedding.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/embedding.cc
@@ -12,7 +12,7 @@ static std::optional<milliseconds_t>
   auto weight = acc.get_tensor<Permissions::RO>(TensorSlotName::WEIGHT);
   auto output = acc.get_tensor<Permissions::WO>(TensorSlotName::OUTPUT);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   EmbeddingAttrs attrs = acc.get_op_attrs().require_embedding();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
@@ -39,7 +39,7 @@ static std::optional<milliseconds_t>
   auto weight_grad =
       acc.get_tensor_grad<Permissions::RW>(TensorSlotName::WEIGHT);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   EmbeddingAttrs attrs = acc.get_op_attrs().require_embedding();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 

--- a/lib/task-spec/src/task-spec/ops/impl/flat.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/flat.cc
@@ -8,7 +8,7 @@ using namespace FlexFlow::Kernels::Flat;
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
   auto output = acc.get_tensor<Permissions::WO>(TensorSlotName::OUTPUT);
@@ -23,7 +23,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/gather.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/gather.cc
@@ -54,7 +54,7 @@ static DeviceSpecificPerDeviceOpState
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   GatherPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_gather().value();
@@ -75,7 +75,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   GatherPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_gather().value();

--- a/lib/task-spec/src/task-spec/ops/impl/layer_norm.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/layer_norm.cc
@@ -36,7 +36,7 @@ static std::optional<milliseconds_t>
   auto gamma = acc.get_tensor<Permissions::RW>(TensorSlotName::GAMMA);
   auto beta = acc.get_tensor<Permissions::RW>(TensorSlotName::BETA);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   LayerNormPerDeviceState state =
       acc.get_per_device_op_state().require_layer_norm().value();
@@ -63,7 +63,7 @@ static std::optional<milliseconds_t>
   auto output_grad =
       acc.get_tensor_grad<Permissions::RO>(TensorSlotName::OUTPUT);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   LayerNormPerDeviceState state =
       acc.get_per_device_op_state().require_layer_norm().value();

--- a/lib/task-spec/src/task-spec/ops/impl/linear.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/linear.cc
@@ -46,7 +46,7 @@ static std::optional<milliseconds_t>
 
   LinearAttrs attrs = acc.get_op_attrs().require_linear();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   std::optional<LinearPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_linear();
 
@@ -83,7 +83,7 @@ static std::optional<milliseconds_t>
 
   LinearAttrs attrs = acc.get_op_attrs().require_linear();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   std::optional<LinearPerDeviceState> per_device_state =
       acc.get_per_device_op_state().require_linear();
 

--- a/lib/task-spec/src/task-spec/ops/impl/pool_2d.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/pool_2d.cc
@@ -68,7 +68,7 @@ static DeviceSpecificPerDeviceOpState
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   Pool2DPerDeviceState state =
       acc.get_per_device_op_state().require_pool_2d().value();
@@ -87,7 +87,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   Pool2DPerDeviceState state =
       acc.get_per_device_op_state().require_pool_2d().value();

--- a/lib/task-spec/src/task-spec/ops/impl/reduce.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/reduce.cc
@@ -39,7 +39,7 @@ static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
   ReducePerDeviceState per_device_state =
       acc.get_per_device_op_state().require_reduce().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
@@ -58,7 +58,7 @@ static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
   ReducePerDeviceState per_device_state =
       acc.get_per_device_op_state().require_reduce().value();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input_grad = acc.get_tensor_grad<Permissions::WO>(TensorSlotName::INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/reshape.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/reshape.cc
@@ -23,7 +23,7 @@ using namespace FlexFlow::Kernels::Reshape;
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ReshapeAttrs attrs = acc.get_op_attrs().require_reshape();
 
@@ -40,7 +40,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ReshapeAttrs attrs = acc.get_op_attrs().require_reshape();
 

--- a/lib/task-spec/src/task-spec/ops/impl/reverse.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/reverse.cc
@@ -27,7 +27,7 @@ using coord_t = long long;
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ReverseAttrs attrs = acc.get_op_attrs().require_reverse();
 
@@ -45,7 +45,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   ReverseAttrs attrs = acc.get_op_attrs().require_reverse();
 

--- a/lib/task-spec/src/task-spec/ops/impl/softmax.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/softmax.cc
@@ -53,7 +53,7 @@ static DeviceSpecificPerDeviceOpState
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   SoftmaxPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_softmax().value();
@@ -72,7 +72,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   SoftmaxPerDeviceState per_device_state =
       acc.get_per_device_op_state().require_softmax().value();

--- a/lib/task-spec/src/task-spec/ops/impl/split.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/split.cc
@@ -42,7 +42,7 @@ static std::pair<positive_int, positive_int>
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   SplitAttrs attrs = acc.get_op_attrs().require_split();
 
@@ -71,7 +71,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   SplitAttrs attrs = acc.get_op_attrs().require_split();
 

--- a/lib/task-spec/src/task-spec/ops/impl/topk.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/topk.cc
@@ -25,7 +25,7 @@ using namespace FlexFlow::Kernels::TopK;
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
   TopKAttrs attrs = acc.get_op_attrs().require_topk();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
@@ -52,7 +52,7 @@ static std::optional<milliseconds_t>
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
   auto attrs = acc.get_op_attrs().require_topk();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   auto input_grad = acc.get_tensor_grad<Permissions::RW>(TensorSlotName::INPUT);

--- a/lib/task-spec/src/task-spec/ops/impl/transpose.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/transpose.cc
@@ -25,7 +25,7 @@ namespace FlexFlow {
 
 static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   TransposeAttrs attrs = acc.get_op_attrs().require_transpose();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
@@ -43,7 +43,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   TransposeAttrs attrs = acc.get_op_attrs().require_transpose();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 

--- a/lib/task-spec/src/task-spec/ops/impl/upsample.cc
+++ b/lib/task-spec/src/task-spec/ops/impl/upsample.cc
@@ -8,7 +8,7 @@ static std::optional<milliseconds_t>
     forward_task_impl(TaskArgumentAccessor const &acc) {
 
   UpsampleAttrs attrs = acc.get_op_attrs().require_upsample();
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
   auto input = acc.get_tensor<Permissions::RO>(TensorSlotName::INPUT);
   auto output = acc.get_tensor<Permissions::WO>(TensorSlotName::OUTPUT);
@@ -24,7 +24,7 @@ static std::optional<milliseconds_t>
 
 static std::optional<milliseconds_t>
     backward_task_impl(TaskArgumentAccessor const &acc) {
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   UpsampleAttrs attrs = acc.get_op_attrs().require_upsample();

--- a/lib/task-spec/src/task-spec/optimizer.cc
+++ b/lib/task-spec/src/task-spec/optimizer.cc
@@ -12,7 +12,7 @@ static void sgd_update_task_impl(TaskArgumentAccessor const &acc) {
   auto weight_grad =
       acc.get_tensor_grad<Permissions::RO>(TensorSlotName::OUTPUT);
   auto weight = acc.get_tensor<Permissions::RW>(TensorSlotName::OUTPUT);
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   ASSERT(weight.shape == weight_grad.shape);
@@ -61,7 +61,7 @@ static void adam_update_task_impl(TaskArgumentAccessor const &acc) {
   auto m_tensor = acc.get_optimizer_tensor<Permissions::RW>(
       TensorSlotName::WEIGHT, OptimizerSlotName::ADAM_M);
 
-  ProfilingSettings profiling = acc.get_profiling_settings();
+  std::optional<ProfilingSettings> profiling = acc.get_profiling_settings();
   DeviceType kernel_device_type = acc.get_kernel_device_type();
 
   ASSERT(weight.shape == weight_grad.shape);

--- a/lib/task-spec/src/task-spec/task_argument_accessor/task_argument_accessor.cc
+++ b/lib/task-spec/src/task-spec/task_argument_accessor/task_argument_accessor.cc
@@ -2,7 +2,8 @@
 
 namespace FlexFlow {
 
-ProfilingSettings TaskArgumentAccessor::get_profiling_settings() const {
+std::optional<ProfilingSettings>
+    TaskArgumentAccessor::get_profiling_settings() const {
   return this->ptr->get_profiling_settings();
 }
 


### PR DESCRIPTION
 * Most places now take `std::optional<ProfilingSettings>`
 * The meaning of `std::nullopt` in this case is "don't profile, just run the kernel exactly once"
 * The reason to bypass profiling is that, for GPU tasks, profiling forces a wait on the GPU stream, which is unacceptable in production code
 * Specific cases:
   * local-execution: profiling is optional
   * cost estimator: profiling is mandatory
   * realm-execution: profiling has been removed entirely; we never actually reported the results and Realm has better ways of profiling that don't involve blocking

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexflow/flexflow-train/1681)
<!-- Reviewable:end -->
